### PR TITLE
Improves initialization in useMonaco.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,8 +13,13 @@ import ReactDOM from 'https://cdn.pika.dev/react-dom';
 import htm from 'https://cdn.pika.dev/htm';
 const html = htm.bind(React.createElement);
 
- createState(1);
-
+createState({
+	data: { count: 0 },
+	on: { INCREMENTED: 'increment' },
+	actions: {
+		increment: (data) => data.scount++
+	}
+});
 
 let Editor = () => {
   const { containerRef, monaco, model, loading } = useMonacoEditor({
@@ -37,17 +42,23 @@ ReactDOM.render(html\`<\${Editor} />\`, document.getElementById('root'));
 
 let Editor = () => {
   const { containerRef } = useMonacoEditor({
-    plugins: ['prettier', 'typings'],
+    languages: ['javascript', 'typescript'],
+    plugins: [plugins.prettier({ semi: false }), 'typings'],
     onLoad: (monaco) => {
-      monaco.languages.typescript?.loadTypes('faunadb', '2.13.0');
-      monaco.languages.typescript?.loadTypes('state-designer', '1.3.35');
-      monaco.languages.typescript?.loadTypes('@state-designer/core', '1.3.35');
-      monaco.languages.typescript?.loadTypes('@state-designer/react', '1.3.35');
-      monaco.languages.typescript?.exposeGlobal(
-        `import { createState as _createState } from 'state-designer';`,
+      if (!monaco.languages.typescript) {
+        console.warn(
+          'You need to add the typescript language in order to load types.'
+        );
+        return;
+      }
+
+      monaco.languages.typescript.loadTypes('faunadb', '2.13.0');
+      monaco.languages.typescript.loadTypes('@state-designer/core', '1.3.35');
+      monaco.languages.typescript.exposeGlobal(
+        `import { createState as _createState } from '@state-designer/core';`,
         `export const createState: typeof _createState;`
       );
-      monaco.languages.typescript?.exposeGlobal(
+      monaco.languages.typescript.exposeGlobal(
         `import { query } from 'faunadb';`,
         `export const q: typeof query;`
       );

--- a/pages/monaco-provider.tsx
+++ b/pages/monaco-provider.tsx
@@ -1,0 +1,73 @@
+import {
+  MonacoProvider,
+  useMonacoContext,
+  useTextModel,
+  useEditor,
+} from '../src';
+
+export default function MonacoProviderPage() {
+  return (
+    <MonacoProvider
+      plugins={['typings']}
+      languages={['javascript', 'typescript']}
+      workersPath={
+        process.env.VERCEL_URL
+          ? `https://${process.env.VERCEL_URL}`
+          : 'http://localhost:3000' + '/_next/static/workers'
+      }
+      languagesPath="/languages/"
+    >
+      <Editor />
+    </MonacoProvider>
+  );
+}
+
+const code = `
+import { createState } from "@state-designer/core"
+
+createState({
+	data: { count: 0 },
+	on: { INCREMENTED: 'increment' },
+	actions: {
+		increment: (data) => data.count++
+	}
+});
+
+USER
+`;
+
+function Editor() {
+  const { monaco, useMonacoEffect } = useMonacoContext();
+
+  const model = useTextModel({
+    monaco,
+    path: 'index.ts',
+    defaultContents: code,
+    language: 'typescript',
+  });
+
+  const { containerRef } = useEditor({ model });
+
+  useMonacoEffect((monaco) => {
+    if (!monaco.languages.typescript) {
+      console.warn(
+        'You need to add the typescript language in order to load types.'
+      );
+      return;
+    }
+
+    monaco.languages.typescript.loadTypes?.('@state-designer/core', '1.3.35');
+    monaco.languages.typescript.exposeGlobal?.(
+      `import { createState as _createState } from '@state-designer/core';`,
+      `export const USER: { name: string, age: number };
+			 export const createState: typeof _createState;`
+    );
+  });
+
+  return (
+    <div>
+      <h1>Monaco Provider Example</h1>
+      <div ref={containerRef} style={{ height: 800, width: '100%' }}></div>
+    </div>
+  );
+}

--- a/src/monaco/plugin-api.ts
+++ b/src/monaco/plugin-api.ts
@@ -207,7 +207,7 @@ export default (monaco: typeof monacoApi) => {
               : null;
 
           if (!plugin) {
-            throw new Error(`Could'nt resolve plugin, ${plugin}`);
+            throw new Error(`Couldn't resolve plugin, ${plugin}`);
           }
 
           plugin.label = plugin.label ?? plugin.name;

--- a/src/monaco/utils/version.ts
+++ b/src/monaco/utils/version.ts
@@ -1,1 +1,1 @@
-export default '0.0.39'
+export default '0.0.40'

--- a/src/plugins/typings/index.ts
+++ b/src/plugins/typings/index.ts
@@ -68,7 +68,7 @@ export default (
       monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
         defaultCompilerOptions
       );
-      monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+      monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
         defaultCompilerOptions
       );
 

--- a/src/react/useMonaco.tsx
+++ b/src/react/useMonaco.tsx
@@ -73,18 +73,18 @@ export function useMonacoContext() {
 }
 
 export const useMonaco = ({
-  themes,
-  onThemeChange = () => {},
-  onLoad,
+  plugins = [],
+  languages = ['javascript', 'typescript', 'html', 'css', 'json'],
   defaultEditorOptions = {
     automaticLayout: true,
     minimap: {
       enabled: false,
     },
   },
-  plugins = [],
+  onLoad,
   theme,
-  languages = ['javascript', 'typescript', 'html', 'css', 'json'],
+  themes,
+  onThemeChange = () => {},
   ...loaderOptions
 }: UseMonacoOptions = {}): CreatedMonacoContext => {
   // Loading (unset once we have initialized monaco)
@@ -123,11 +123,6 @@ export const useMonaco = ({
         cancelable = loadMonaco(loaderOptions ?? {});
         monaco = await cancelable;
       }
-
-      // Install and setup plugins.
-      pluginDisposable = await monaco.plugin.install(
-        ...getPlugins(plugins, languages)
-      );
 
       // Perform any onLoad tasks.
       if (onLoad) {

--- a/src/react/useMonaco.tsx
+++ b/src/react/useMonaco.tsx
@@ -84,7 +84,7 @@ export const useMonaco = ({
   onLoad,
   theme,
   themes,
-  onThemeChange = () => {},
+  onThemeChange,
   ...loaderOptions
 }: UseMonacoOptions = {}): CreatedMonacoContext => {
   // Loading (unset once we have initialized monaco)
@@ -124,6 +124,10 @@ export const useMonaco = ({
         monaco = await cancelable;
       }
 
+      monaco.plugin
+        .install(...getPlugins(plugins, languages))
+        .then((d) => (pluginDisposable = asDisposable(d)));
+
       // Perform any onLoad tasks.
       if (onLoad) {
         const disposables = await onLoad(monaco);
@@ -150,21 +154,6 @@ export const useMonaco = ({
       onLoadDisposable?.dispose();
     };
   }, [monaco]);
-
-  // Handle changed plugins or languages
-  React.useEffect(() => {
-    if (!monaco) return;
-    // Install and setup plugins.
-    let disposable: monacoApi.IDisposable;
-
-    monaco.plugin
-      .install(...getPlugins(plugins, languages))
-      .then((d) => (disposable = asDisposable(d)));
-
-    return () => {
-      disposable?.dispose();
-    };
-  }, [monaco, plugins, languages]);
 
   // Setup onThemeChange event handler
   React.useEffect(() => {

--- a/src/react/useMonaco.tsx
+++ b/src/react/useMonaco.tsx
@@ -83,7 +83,7 @@ export const useMonaco = ({
     },
   },
   plugins = [],
-  theme = 'ayu-light',
+  theme,
   languages = ['javascript', 'typescript', 'html', 'css', 'json'],
   ...loaderOptions
 }: UseMonacoOptions = {}): CreatedMonacoContext => {


### PR DESCRIPTION
This PR fixes problems where the Monaco instance was not unloading and reloading correctly, in particular during Next.js's fast refresh implementation. 

On the current main branch, changing the initial code could cause the editor to disappear on fast refresh, requiring a manual refresh to load back up. Changing routes could also cause the Monaco instance on Window to be recycled without accounting for new plugins or languages on the new route.

The changes amount to a reshuffle of the `useMonaco` file: moving the Monaco instance into state (instead of a ref); initializing that state with the Monaco instance in the window, if present; splitting up the initialization effect into smaller effects for plugins and languages, theme, and themes; and other organizational improvements.

This PR also:
- includes an example of a MonacoProvider pattern.
- includes minor fixes to other files.